### PR TITLE
Add support for function terms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Effects"
 uuid = "8f03c58b-bd97-4933-a826-f71b64d2cca2"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -33,4 +33,4 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames", "GLM", "MixedModels", "StableRNGs", "Statistics", "StatsModels", "StandardizedPredictors", "Test"]
+test = ["DataFrames", "GLM", "MixedModels", "StableRNGs", "StatsBase", "StatsModels", "StandardizedPredictors", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -29,6 +29,7 @@ MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StandardizedPredictors = "5064a6a7-f8c2-40e2-8bdc-797ec6f1ae18"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/typical.jl
+++ b/src/typical.jl
@@ -61,10 +61,10 @@ function typify(refgrid, model_formula::FormulaTerm,
     # creates a MatrixTerm (and should work for things like MixedModels) which
     # should correspond to the model_matrix
     matrix_term = get_matrix_term(model_formula.rhs)
-
     typical_terms = Dict()
-    for term in terms(matrix_term)
-        if !any(et -> StatsModels.symequal(et, term), effects_terms)
+    # calling terms() here gives us something we don't want for the function terms
+    for term in matrix_term.terms
+        if !any(et -> _symequal(et, term), effects_terms)
             typical_terms[term] = typicalterm(term, matrix_term, model_matrix; typical=typical)
         end
     end
@@ -76,8 +76,21 @@ _replace(matrix_term::MatrixTerm, typicals::Dict) = MatrixTerm(_replace.(matrix_
 _replace(term::AbstractTerm, typicals::Dict) = haskey(typicals, term) ? typicals[term] : term
 _replace(term::InteractionTerm, typicals::Dict) = InteractionTerm(_replace.(term.terms, Ref(typicals)))
 
+_termsyms(t) = StatsModels.termsyms(t)
+_termsyms(t::FunctionTerm) = Set(_termsyms.(t.args_parsed)...)
+_symequal(t1::AbstractTerm, t2::AbstractTerm) = issetequal(_termsyms(t1), _termsyms(t2))
+
+_trmequal(t1::AbstractTerm, t2::AbstractTerm) = issetequal(_termsyms(t1), _termsyms(t2))
+_trmequal(t1::AbstractTerm, t2::FunctionTerm) = false
+_trmequal(t1::FunctionTerm, t2::AbstractTerm) = false
+function _trmequal(t1::FunctionTerm, t2::FunctionTerm)
+    return t1.exorig == t2.exorig &&
+        t1.args_parsed == t2.args_parsed &&
+        t1.forig == t2.forig
+end
+
 function typicalterm(term::AbstractTerm, context::MatrixTerm, model_matrix; typical=mean)
-    i = findfirst(t -> StatsModels.symequal(t, term), context.terms)
+    i = findfirst(t -> _trmequal(t, term), context.terms)
     i === nothing && throw(ArgumentError("Can't determine columns corresponding to '$term' in matrix term $context"))
     cols = (i == 1 ? 0 : sum(width, context.terms[1:(i - 1)])) .+ (1:width(term))
     vals = map(typical, eachcol(view(model_matrix, :, cols)))

--- a/src/typical.jl
+++ b/src/typical.jl
@@ -85,7 +85,7 @@ _replace(term::InteractionTerm, typicals::Dict) = InteractionTerm(_replace.(term
 
 _rmliterals(s) = filter(x -> !isa(x, Number), s)
 _termsyms(t) = StatsModels.termsyms(t)
-_termsyms(t::FunctionTerm) = _rmliterals(union(_termsyms.(t.args_parsed)...))
+_termsyms(t::FunctionTerm) = _rmliterals(union(_termsyms.(t.args)...))
 _symequal(t1::AbstractTerm, t2::AbstractTerm) = issetequal(_termsyms(t1), _termsyms(t2))
 
 _trmequal(t1::AbstractTerm, t2::AbstractTerm) = issetequal(_termsyms(t1), _termsyms(t2))
@@ -93,7 +93,7 @@ _trmequal(t1::AbstractTerm, t2::FunctionTerm) = false
 _trmequal(t1::FunctionTerm, t2::AbstractTerm) = false
 function _trmequal(t1::FunctionTerm, t2::FunctionTerm)
     return t1.exorig == t2.exorig &&
-        t1.args_parsed == t2.args_parsed &&
+        t1.args == t2.args &&
         t1.forig == t2.forig
 end
 

--- a/src/typical.jl
+++ b/src/typical.jl
@@ -62,7 +62,7 @@ function typify(refgrid, model_formula::FormulaTerm,
     typical_terms = Dict()
 
     urterms = terms(matrix_term)
-    nonfunc_terms = [filter(tt -> !isa(tt, FunctionTerm), matrix_term.terms)...]
+    nonfunc_terms = [tt for tt in matrix_term.terms if !isa(tt, FunctionTerm)]
     # only include generating terms that exist outside of a FunctionTerm
     filter!(urterms) do tt
         return any(x -> _termsyms(tt) < _termsyms(x), nonfunc_terms)

--- a/src/typical.jl
+++ b/src/typical.jl
@@ -83,7 +83,6 @@ _replace(matrix_term::MatrixTerm, typicals::Dict) = MatrixTerm(_replace.(matrix_
 _replace(term::AbstractTerm, typicals::Dict) = haskey(typicals, term) ? typicals[term] : term
 _replace(term::InteractionTerm, typicals::Dict) = InteractionTerm(_replace.(term.terms, Ref(typicals)))
 
-_rmliterals(s) = filter(x -> !isa(x, Number), s)
 _termsyms(t) = StatsModels.termsyms(t)
 _termsyms(t::FunctionTerm{Fo, Fa, Names}) where {Fo, Fa, Names} = Names
 _symequal(t1::AbstractTerm, t2::AbstractTerm) = issetequal(_termsyms(t1), _termsyms(t2))

--- a/src/typical.jl
+++ b/src/typical.jl
@@ -85,15 +85,15 @@ _replace(term::InteractionTerm, typicals::Dict) = InteractionTerm(_replace.(term
 
 _rmliterals(s) = filter(x -> !isa(x, Number), s)
 _termsyms(t) = StatsModels.termsyms(t)
-_termsyms(t::FunctionTerm) = _rmliterals(union(_termsyms.(t.args)...))
+_termsyms(t::FunctionTerm{Fo, Fa, Names}) where {Fo, Fa, Names} = Names
 _symequal(t1::AbstractTerm, t2::AbstractTerm) = issetequal(_termsyms(t1), _termsyms(t2))
 
-_trmequal(t1::AbstractTerm, t2::AbstractTerm) = issetequal(_termsyms(t1), _termsyms(t2))
+_trmequal(t1::AbstractTerm, t2::AbstractTerm) = _symequal(t1, t2)
 _trmequal(t1::AbstractTerm, t2::FunctionTerm) = false
 _trmequal(t1::FunctionTerm, t2::AbstractTerm) = false
 function _trmequal(t1::FunctionTerm, t2::FunctionTerm)
     return t1.exorig == t2.exorig &&
-        t1.args == t2.args &&
+        _symequal(t1, t2) &&
         t1.forig == t2.forig
 end
 

--- a/src/typical.jl
+++ b/src/typical.jl
@@ -68,7 +68,6 @@ function typify(refgrid, model_formula::FormulaTerm,
             typical_terms[term] = typicalterm(term, matrix_term, model_matrix; typical=typical)
         end
     end
-
     return _replace(matrix_term, typical_terms)
 end
 
@@ -77,7 +76,8 @@ _replace(term::AbstractTerm, typicals::Dict) = haskey(typicals, term) ? typicals
 _replace(term::InteractionTerm, typicals::Dict) = InteractionTerm(_replace.(term.terms, Ref(typicals)))
 
 _termsyms(t) = StatsModels.termsyms(t)
-_termsyms(t::FunctionTerm) = Set(_termsyms.(t.args_parsed)...)
+_termsyms(t::FunctionTerm) = _rmliterals(union(_termsyms.(t.args_parsed)...))
+_rmliterals(s) = filter(x -> !isa(x, Number), s)
 _symequal(t1::AbstractTerm, t2::AbstractTerm) = issetequal(_termsyms(t1), _termsyms(t2))
 
 _trmequal(t1::AbstractTerm, t2::AbstractTerm) = issetequal(_termsyms(t1), _termsyms(t2))

--- a/src/typical.jl
+++ b/src/typical.jl
@@ -72,10 +72,10 @@ function typify(refgrid, model_formula::FormulaTerm,
     func_terms = [filter(tt -> isa(tt, FunctionTerm), matrix_term.terms)...]
     for term in [urterms; func_terms]
         if !any(et -> _symequal(et, term), effects_terms)
-            # @show term
             typical_terms[term] = typicalterm(term, matrix_term, model_matrix; typical=typical)
         end
     end
+
     return _replace(matrix_term, typical_terms)
 end
 

--- a/test/typical.jl
+++ b/test/typical.jl
@@ -1,5 +1,6 @@
 using DataFrames
 using Effects
+using StatsBase
 using StatsModels
 using MixedModels: MixedModel, ReMat
 using Test
@@ -9,6 +10,7 @@ using Effects: _reference_grid
 
 x = collect(-10:19)
 dat = DataFrame(; x=x,
+                w = exp.(x),
                 z=repeat(["A", "B", "C"]; inner=10),
                 y=zeros(length(x)))
 
@@ -98,4 +100,17 @@ end
     y, X = modelcols(f, dat)
     refgrid = _reference_grid(Dict(:x => [π]))
     @test_throws ArgumentError typify(refgrid, f, X)
+end
+
+@testset "functionterm" begin
+    form = @formula(y ~ 0 + x + log(w) + sqrt(w) + w)
+    f = apply_schema(form, schema(form, dat))
+    rhs = f.rhs
+
+    X = modelcols(rhs, dat)
+    refgrid = _reference_grid(Dict(:x => [π]))
+    @test modelcols(typify(refgrid, f, X), refgrid) ≈ Float64[π mean(log.(dat.w)) mean(sqrt.(dat.w)) mean(dat.w)]
+
+    refgrid = _reference_grid(Dict(:x => [π], :w => [π]))
+    @test modelcols(typify(refgrid, f, X), refgrid) ≈ Float64[π log(π) sqrt(π) π]
 end

--- a/test/typical.jl
+++ b/test/typical.jl
@@ -106,11 +106,16 @@ end
     form = @formula(y ~ 0 + x + log(w) + sqrt(w) + w)
     f = apply_schema(form, schema(form, dat))
     rhs = f.rhs
-
     X = modelcols(rhs, dat)
     refgrid = _reference_grid(Dict(:x => [π]))
     @test modelcols(typify(refgrid, f, X), refgrid) ≈ Float64[π mean(log.(dat.w)) mean(sqrt.(dat.w)) mean(dat.w)]
-
     refgrid = _reference_grid(Dict(:x => [π], :w => [π]))
     @test modelcols(typify(refgrid, f, X), refgrid) ≈ Float64[π log(π) sqrt(π) π]
+
+    form = @formula(y ~ 0 + x + x^2 + x^3)
+    f = apply_schema(form, schema(form, dat))
+    rhs = f.rhs
+    X = modelcols(rhs, dat)
+    refgrid = _reference_grid(Dict(:x => [π]))
+    @test modelcols(typify(refgrid, f, X), refgrid) ≈ Float64[π π^2 π^3]
 end

--- a/test/typical.jl
+++ b/test/typical.jl
@@ -102,6 +102,19 @@ end
     @test_throws ArgumentError typify(refgrid, f, X)
 end
 
+@testset "_trmequal" begin
+    # get that 100% coverage
+    form = @formula(y ~ 0 + x + x^2 + x^3)
+    f = apply_schema(form, schema(form, dat))
+    terms = f.rhs.terms
+    # terms[3] is the quadratic FunctionTerm
+    # terms[2] is the linear Continuous
+    @test !Effects._trmequal(terms[3], terms[2])
+    @test !Effects._trmequal(terms[2], terms[3])
+    @test Effects._trmequal(terms[2], terms[2])
+    @test Effects._trmequal(terms[3], terms[3])
+end
+
 @testset "FunctionTerm" begin
     # no untransformed w here -- we want to make sure we don't try
     # to grab the nonexistent column corresponding to untransformed w

--- a/test/typical.jl
+++ b/test/typical.jl
@@ -102,15 +102,17 @@ end
     @test_throws ArgumentError typify(refgrid, f, X)
 end
 
-@testset "functionterm" begin
-    form = @formula(y ~ 0 + x + log(w) + sqrt(w) + w)
+@testset "FunctionTerm" begin
+    # no untransformed w here -- we want to make sure we don't try
+    # to grab the nonexistent column corresponding to untransformed w
+    form = @formula(y ~ 0 + x + log(w) + sqrt(w))
     f = apply_schema(form, schema(form, dat))
     rhs = f.rhs
     X = modelcols(rhs, dat)
     refgrid = _reference_grid(Dict(:x => [π]))
-    @test modelcols(typify(refgrid, f, X), refgrid) ≈ Float64[π mean(log.(dat.w)) mean(sqrt.(dat.w)) mean(dat.w)]
+    @test modelcols(typify(refgrid, f, X), refgrid) ≈ Float64[π mean(log.(dat.w)) mean(sqrt.(dat.w))]
     refgrid = _reference_grid(Dict(:x => [π], :w => [π]))
-    @test modelcols(typify(refgrid, f, X), refgrid) ≈ Float64[π log(π) sqrt(π) π]
+    @test modelcols(typify(refgrid, f, X), refgrid) ≈ Float64[π log(π) sqrt(π)]
 
     form = @formula(y ~ 0 + x + x^2 + x^3)
     f = apply_schema(form, schema(form, dat))


### PR DESCRIPTION
I like the idea of being able to support `FunctionTerm`, but there is a massive potential footgun here. For example, if we have  `1 + sqrt(x) + x` , then the typical values of `x` and `sqrt(x)` make never co-occur in real data. At the same time, we don't always have access to `x` and `f(x)` might not be invertible, so we can't just go back to the untransformed variable to compute the typical values.

Closes #24 
Closes #25 (I think)