### PR TITLE
Allow improper subsets (i.e. set equivalence) when matching term symbols

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Effects"
 uuid = "8f03c58b-bd97-4933-a826-f71b64d2cca2"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/typical.jl
+++ b/src/typical.jl
@@ -65,7 +65,7 @@ function typify(refgrid, model_formula::FormulaTerm,
     nonfunc_terms = [tt for tt in matrix_term.terms if !isa(tt, FunctionTerm)]
     # only include generating terms that exist outside of a FunctionTerm
     filter!(urterms) do tt
-        return any(x -> _termsyms(tt) < _termsyms(x), nonfunc_terms)
+        return any(x -> _termsyms(tt) <= _termsyms(x), nonfunc_terms)
     end
 
     # we need to include FunctionTerms separately so that we can grab the transformed columns


### PR DESCRIPTION
Closes #29 