### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
         with:
-          file: lcov.info
+          files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-uploadcodecov@v0.1
-        if:  ${{ startsWith(matrix.os, 'ubuntu') && (matrix.version == '1') }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          file: lcov.info


### PR DESCRIPTION
PR to update CI using the recommendation from [julia-processcoverage README](https://github.com/julia-actions/julia-processcoverage).

`julia-action/julia-uploadcodecov` is deprecated as mentioned [here](https://github.com/julia-actions/julia-uploadcodecov). The recommendation is to use `julia-actions/julia-processcoverage` in combination with `codecov/codecov-action`.

Note to self: as mentioned in https://github.com/codecov/codecov-action#usage , the secrets token is not required for public repos.

- [x] Assuming tests pass then this should be good to go
