### PR TITLE
zizmor audit

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,8 +8,11 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/YASG.yml
+++ b/.github/workflows/YASG.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           tool_name: JuliaFormatter
-          fail_on_error: true
+          fail_level: error

--- a/.github/workflows/YASG.yml
+++ b/.github/workflows/YASG.yml
@@ -20,23 +20,28 @@ jobs:
     # Run on push's or non-draft PRs
     if: (github.event_name == 'push') || (github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         julia-version: [1.9]
     steps:
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39  # v3.0.1
         with:
           version: ${{ matrix.julia-version }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Cache
-        uses: julia-actions/cache@v3
+        uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3
         with:
             cache-compiled: "true"
       - name: Instantiate `format` environment and format
         run: |
           julia --project=format -O0 -e 'using Pkg; Pkg.instantiate()'
           julia --project=format -O0 'format/run.jl'
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         if: github.event_name == 'pull_request'
         with:
           tool_name: JuliaFormatter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -27,18 +29,20 @@ jobs:
           - x64
           # - x86
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache
-        uses: julia-actions/cache@v3
+        uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3
         with:
             cache-compiled: "true"
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1
+      - uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # v1
+      - uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38 # v1
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: lcov.info

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -7,11 +7,14 @@ on:
 jobs:
   doc-preview-cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: gh-pages
+          persist-credentials: false
       - name: Delete preview and history + push changes
         run: |
             if [ -d "previews/PR$PRNUM" ]; then

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -10,17 +10,22 @@ jobs:
   Documenter:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: 1
       - name: Cache
-        uses: julia-actions/cache@v3
+        uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3
         with:
             cache-compiled: "true"
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-docdeploy@latest
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1  # v1.7.0
+      - uses: julia-actions/julia-docdeploy@e62cc8fd639797a0c2922a437d5b1b81c4a12787  # v1.3.1
         env:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # when run by tagbot
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         with:
           tool_name: Typos
-          fail_on_error: true
+          fail_level: error

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,15 +7,20 @@ jobs:
   typos-check:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Check spelling
         uses: crate-ci/typos@631208b7aac2daa8b707f55e7331f9112b0e062d # v1.44.0
         with:
             config: _typos.toml
             write_changes: true
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         with:
           tool_name: Typos
           fail_on_error: true

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,28 @@
+---
+name: GitHub Actions Security Analysis with zizmor 🌈
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+permissions: {}
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      # security-events: write  # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read  # Only needed for private repos. Needed to clone the repo.
+      # actions: read  # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
| Workflow | Job | Permissions Before | Permissions After | Rationale |
|---|---|---|---|---|
| CompatHelper.yml | CompatHelper | none (default) | `contents: write`, `pull-requests: write` | CompatHelper creates PRs to update compat bounds |
| TagBot.yml | TagBot | none (default) | `contents: write`, `issues: read` | TagBot creates git tags; triggered by `issue_comment` |
| YASG.yml | format-check | none (default) | `contents: read`, `pull-requests: write` | Checkout needs read; reviewdog/action-suggester posts PR suggestions |
| ci.yml | test | none (default) | `contents: read` | Read-only: checkout, test, coverage upload |
| docs-cleanup.yml | doc-preview-cleanup | none (default) | `contents: write` | Force-pushes to `gh-pages` branch to remove PR preview |
| documenter.yml | Documenter | none (default) | `contents: write`, `statuses: write` | julia-docdeploy deploys to gh-pages; Documenter.jl posts commit statuses |
| spellcheck.yml | typos-check | none (default) | `contents: read`, `pull-requests: write` | Checkout needs read; reviewdog/action-suggester posts PR suggestions |
| zizmor.yaml | zizmor | — (new file) | `contents: read` | New workflow; read-only repo scan |
